### PR TITLE
Push some WIP multiple assignees changes to Maddin2016

### DIFF
--- a/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssuesClientTests.cs
@@ -7,7 +7,6 @@ using Octokit;
 using Octokit.Tests.Integration;
 using Xunit;
 using Octokit.Tests.Integration.Helpers;
-using System.Collections.Generic;
 
 public class IssuesClientTests : IDisposable
 {
@@ -39,18 +38,24 @@ public class IssuesClientTests : IDisposable
     }
 
     [IntegrationTest]
-    public async Task CanCreateRetrieveAndCloseIssue()
+    public async Task CanCreateAssignRetrieveAndCloseIssue()
     {
         var newIssue = new NewIssue("a test issue") { Body = "A new unassigned issue" };
+        newIssue.Labels.Add("test");
+        newIssue.Assignees.Add(_context.RepositoryOwner);
+
         var issue = await _issuesClient.Create(_context.RepositoryOwner, _context.RepositoryName, newIssue);
         try
         {
             Assert.NotNull(issue);
+            Assert.True(issue.Assignees.All(x => x.Login == _context.RepositoryOwner));
 
             var retrieved = await _issuesClient.Get(_context.RepositoryOwner, _context.RepositoryName, issue.Number);
             var all = await _issuesClient.GetAllForRepository(_context.RepositoryOwner, _context.RepositoryName);
             Assert.NotNull(retrieved);
-            Assert.True(all.Any(i => i.Number == retrieved.Number));
+            Assert.True(retrieved.Assignees.Count == 1);
+            Assert.True(retrieved.Assignees[0].Login == _context.RepositoryOwner);
+            Assert.True(all.Any(i => i.Number == retrieved.Number && i.Assignees.Count == 1 && i.Assignees[0].Login == _context.RepositoryOwner));
         }
         finally
         {
@@ -58,6 +63,8 @@ public class IssuesClientTests : IDisposable
             new IssueUpdate { State = ItemState.Closed })
             .Result;
             Assert.NotNull(closed);
+            Assert.True(closed.Assignees.Count == 1);
+            Assert.True(closed.Assignees[0].Login == _context.RepositoryOwner);
         }
     }
 
@@ -184,6 +191,22 @@ public class IssuesClientTests : IDisposable
         Assert.True(retrieved.Any(i => i.Number == issue2.Number));
         Assert.True(retrieved.Any(i => i.Number == issue3.Number));
         Assert.True(retrieved.Any(i => i.Number == issue4.Number));
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveIssueWithMultipleAssignees()
+    {
+        var issue = await _issuesClient.Get("octokit", "octokit.net", 1171);
+
+        Assert.True(issue.Assignees.Count == 2);
+    }
+
+    [IntegrationTest]
+    public async Task CanRetrieveIssuesWithMultipleAssignees()
+    {
+        var issues = await _issuesClient.GetAllForRepository("octokit", "octokit.net");
+
+        Assert.True(issues.Any(x => x.Assignees.Count > 0));
     }
 
     [IntegrationTest]

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -62,7 +62,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, "owner");
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
 
-            return ApiConnection.Get<Issue>(ApiUrls.Issue(owner, name, number));
+            return ApiConnection.Get<Issue>(ApiUrls.Issue(owner, name, number), null, AcceptHeaders.MultipleAssigneesPreview);
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(request, "request");
 
-            return ApiConnection.GetAll<Issue>(ApiUrls.Issues(owner, name), request.ToParametersDictionary());
+            return ApiConnection.GetAll<Issue>(ApiUrls.Issues(owner, name), request.ToParametersDictionary(), AcceptHeaders.MultipleAssigneesPreview);
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(newIssue, "newIssue");
 
-            return ApiConnection.Post<Issue>(ApiUrls.Issues(owner, name), newIssue);
+            return ApiConnection.Post<Issue>(ApiUrls.Issues(owner, name), newIssue, AcceptHeaders.MultipleAssigneesPreview);
         }
 
         /// <summary>
@@ -223,7 +223,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(name, "name");
             Ensure.ArgumentNotNull(issueUpdate, "issueUpdate");
 
-            return ApiConnection.Patch<Issue>(ApiUrls.Issue(owner, name, number), issueUpdate);
+            return ApiConnection.Patch<Issue>(ApiUrls.Issue(owner, name, number), issueUpdate, AcceptHeaders.MultipleAssigneesPreview);
         }
 
         /// <summary>

--- a/Octokit/Helpers/AcceptHeaders.cs
+++ b/Octokit/Helpers/AcceptHeaders.cs
@@ -20,6 +20,8 @@
 
         public const string SquashCommitPreview = "application/vnd.github.polaris-preview+json";
 
-        public const string MigrationsApiPreview = "  application/vnd.github.wyandotte-preview+json";
+        public const string MigrationsApiPreview = "application/vnd.github.wyandotte-preview+json";
+
+        public const string MultipleAssigneesPreview = "application/vnd.github.cerberus-preview";
     }
 }

--- a/Octokit/Models/Request/IssueUpdate.cs
+++ b/Octokit/Models/Request/IssueUpdate.cs
@@ -27,8 +27,15 @@ namespace Octokit
         /// <remarks>
         /// Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise.
         /// </remarks>
-        [SerializeNull]
         public string Assignee { get; set; }
+
+        /// <summary>
+        /// List of logins for the multiple users that this issue should be assigned to
+        /// </summary>
+        /// <remarks>
+        /// Only users with push access can set the multiple assignees for new issues.  The assignees are silently dropped otherwise.
+        /// </remarks>
+        public ICollection<string> Assignees { get; private set; }
 
         /// <summary>
         /// Milestone to associate this issue with.
@@ -58,6 +65,37 @@ namespace Octokit
             get
             {
                 return string.Format(CultureInfo.InvariantCulture, "Title: {0}", Title);
+            }
+        }
+
+        /// <summary>
+        /// Adds the specified assigness to the issue.
+        /// </summary>
+        /// <param name="name">The login of the assignee.</param>
+        public void AddAssignee(string name)
+        {
+            // lazily create the assignees array
+            if (Assignees == null)
+            {
+                Assignees = new List<string>();
+            }
+
+            Assignees.Add(name);
+        }
+
+        /// <summary>
+        /// Clears all the assignees.
+        /// </summary>
+        public void ClearAssignees()
+        {
+            // lazily create the label array
+            if (Assignees == null)
+            {
+                Assignees = new List<string>();
+            }
+            else
+            {
+                Assignees.Clear();
             }
         }
 

--- a/Octokit/Models/Request/NewIssue.cs
+++ b/Octokit/Models/Request/NewIssue.cs
@@ -17,6 +17,7 @@ namespace Octokit
         public NewIssue(string title)
         {
             Title = title;
+            Assignees = new Collection<string>();
             Labels = new Collection<string>();
         }
 
@@ -37,6 +38,14 @@ namespace Octokit
         /// Only users with push access can set the assignee for new issues. The assignee is silently dropped otherwise.
         /// </remarks>
         public string Assignee { get; set; }
+
+        /// <summary>
+        /// List of logins for the multiple users that this issue should be assigned to
+        /// </summary>
+        /// <remarks>
+        /// Only users with push access can set the multiple assignees for new issues.  The assignees are silently dropped otherwise.
+        /// </remarks>
+        public Collection<string> Assignees { get; private set; }
 
         /// <summary>
         /// Milestone to associate this issue with.

--- a/Octokit/Models/Response/Issue.cs
+++ b/Octokit/Models/Response/Issue.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 
 namespace Octokit
 {
@@ -95,6 +96,11 @@ namespace Octokit
         public User Assignee { get; protected set; }
 
         /// <summary>
+        /// The multiple users this issue is assigned to.
+        /// </summary>
+        public IReadOnlyList<User> Assignees { get; protected set; }
+
+        /// <summary>
         /// The milestone, if any, that this issue is assigned to.
         /// </summary>
         public Milestone Milestone { get; protected set; }
@@ -149,6 +155,14 @@ namespace Octokit
                 ? null
                 : Assignee.Login;
 
+            var assignees = Assignees == null
+                ? null
+                : Assignees.Select(x => x.Login);
+
+            var labels = Labels == null
+                ? null
+                : Labels.Select(x => x.Name);
+
             var issueUpdate = new IssueUpdate
             {
                 Assignee = assignee,
@@ -157,6 +171,16 @@ namespace Octokit
                 State = State,
                 Title = Title
             };
+
+            foreach (var asignee in assignees)
+            {
+                issueUpdate.AddAssignee(asignee);
+            }
+
+            foreach (var label in labels)
+            {
+                issueUpdate.AddLabel(label);
+            }
 
             return issueUpdate;
         }


### PR DESCRIPTION
Hey @maddin2016 

Following on from my comments at https://github.com/octokit/octokit.net/pull/1339#issuecomment-223736471, here are some changes for the "multiple issue assignees" stuff
- Added "multiple assignees" support to `NewIssue` and `IssueUpdate` calls
- passing accepts header on Get and GetAll issues queries (not mentioned in API docs but the new field is returned fine!).  
- Enhanced a couple of tests to assert the new field is populated correctly.  
- Didnt add any unit tests sorry as this was just a quick probe to see whether the new fields were returned on Get/GetAll
